### PR TITLE
Fix: getPermissions

### DIFF
--- a/package.py
+++ b/package.py
@@ -279,8 +279,8 @@ class Package():
 	def getPermissions(self):
 		print "Getting files permissions..."
 		cmd = "adb " + self.device + " shell su -c 'ls -aRl /data/data/" + self.package + " /sdcard/Android/data/" + self.package + "'"
-                if self.externalStorage:
-                    cmd = cmd[:-1] + " " + self.externalStorage + "/Android/data/"+ self.package + "'"
+		if self.externalStorage:
+			cmd = cmd[:-1] + " " + self.externalStorage + "/Android/data/"+ self.package + "'"
 		writeResultToFile(cmd, self.path + "/permissions", self.verbose)
 		print ""
 	

--- a/package.py
+++ b/package.py
@@ -278,9 +278,9 @@ class Package():
 	
 	def getPermissions(self):
 		print "Getting files permissions..."
-		cmd = "adb " + self.device + " shell su -c ls -aRl /data/data/" + self.package + " /sdcard/Android/data/" + self.package
-		if self.externalStorage:
-			cmd += " " + self.externalStorage + "/Android/data/"+ self.package
+		cmd = "adb " + self.device + " shell su -c 'ls -aRl /data/data/" + self.package + " /sdcard/Android/data/" + self.package + "'"
+                if self.externalStorage:
+                    cmd = cmd[:-1] + " " + self.externalStorage + "/Android/data/"+ self.package + "'"
 		writeResultToFile(cmd, self.path + "/permissions", self.verbose)
 		print ""
 	


### PR DESCRIPTION
Added quotation marks in the command passed to adb. This patch was necessary to get "getPermissions" work on Android 7.1.2.

This is a fix for issue https://github.com/Flo354/Androick/issues/4.